### PR TITLE
Исправление в редиректах

### DIFF
--- a/plg_system_znatok/znatok.php
+++ b/plg_system_znatok/znatok.php
@@ -263,10 +263,16 @@ class plgSystemZnatok extends CMSPlugin
 						if (empty($value)) continue;
 
 						// Add utm variables
-						if (preg_match('#^utm_#i', $name)) $redirect->setVar($name, $value);
+						if (preg_match('#^utm_#i', $name)) {
+                            $redirect->setVar($name, $value);
+                            continue;
+                        }
 
 						// Add Yandex.Metrika debug
-						if ($name === '_ym_debug') $redirect->setVar($name, $value);
+						if ($name === '_ym_debug') {
+                            $redirect->setVar($name, $value);
+                            continue;
+                        }
 
 						// Add allowed variables from params
 						if (in_array($name, $redirect_allowed)) $redirect->setVar($name, $value);

--- a/plg_system_znatok/znatok.php
+++ b/plg_system_znatok/znatok.php
@@ -267,7 +267,7 @@ class plgSystemZnatok extends CMSPlugin
 						if (preg_match('#^UTM_#', $name)) $redirect->setVar($name, $value);
 
 						// Add Yandex.Metrika debug
-						if ($name === '_ym_debug' && $value == 1) $redirect->setVar($name, $value);
+						if ($name === '_ym_debug') $redirect->setVar($name, $value);
 
 						// Add allowed variables from params
 						if (in_array($name, $redirect_allowed)) $redirect->setVar($name, $value);

--- a/plg_system_znatok/znatok.php
+++ b/plg_system_znatok/znatok.php
@@ -263,8 +263,7 @@ class plgSystemZnatok extends CMSPlugin
 						if (empty($value)) continue;
 
 						// Add utm variables
-						if (preg_match('#^utm_#', $name)) $redirect->setVar($name, $value);
-						if (preg_match('#^UTM_#', $name)) $redirect->setVar($name, $value);
+						if (preg_match('#^utm_#i', $name)) $redirect->setVar($name, $value);
 
 						// Add Yandex.Metrika debug
 						if ($name === '_ym_debug') $redirect->setVar($name, $value);

--- a/plg_system_znatok/znatok.php
+++ b/plg_system_znatok/znatok.php
@@ -263,7 +263,7 @@ class plgSystemZnatok extends CMSPlugin
 						if (empty($value)) continue;
 
 						// Add utm variables
-						if (preg_match('#^utm_#i', $name)) {
+						if (strpos(strtolower($name), 'utm_') === 0) {
                             $redirect->setVar($name, $value);
                             continue;
                         }

--- a/plg_system_znatok/znatok.php
+++ b/plg_system_znatok/znatok.php
@@ -262,6 +262,12 @@ class plgSystemZnatok extends CMSPlugin
 						$value = trim($value);
 						if (empty($value)) continue;
 
+                        // Add default Joomla vars
+                        if(in_array($name, array('tmpl', 'format'))) {
+                            $redirect->setVar($name, $value);
+                            continue;
+                        }
+
 						// Add utm variables
 						if (strpos(strtolower($name), 'utm_') === 0) {
                             $redirect->setVar($name, $value);


### PR DESCRIPTION
В цикле, который собирает uri для редиректа:
- Убрал строгую проверку значения, переданного в параметре `_ym_debug`
- Заменил регулярное выражение, на более "лёгкий" `strpos`, при проверке на наличие UTM-меток
- Добавил `continue` при срабатывании любого условия